### PR TITLE
add streaming dataset to featurizer, optional lzo decompression, bug fix to mlp clf multiclass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -154,4 +154,5 @@ punk/
 pipeline_scores/
 distil-primitives/
 backup_annotations/
-bigearth-100-single-multi/
+test_data/bigearth-100-single-multi/
+test_data/bigearth-100-single-2c/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,10 @@ COPY requirements.txt .
 RUN pip install -r requirements.txt
 
 RUN pip install -e git+https://github.com/kungfuai/d3m-primitives#egg=kf-d3m-primitives --upgrade --exists-action=w
-COPY . kf-d3m-primitives
-# RUN pip install -e kf-d3m-primitives
+COPY . .
+RUN pip install -e .
+
+RUN sudo apt-get update -y && \ 
+    sudo apt-get install -y zlib1g-dev && \ 
+    sudo apt-get install -y liblzo2-dev && \ 
+    pip install python-lzo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,5 @@ services:
             - ./test_data:/test_data
             - ./scratch_dir:/scratch_dir
             - ./pipeline_scores:/pipeline_scores
-            #- ./:/kf-d3m-primitives
+            - ./tests:/tests
+            - ./kf_d3m_primitives:/kf_d3m_primitives

--- a/generate_annotations.py
+++ b/generate_annotations.py
@@ -17,10 +17,10 @@ ignore = [
 ]
 
 # List all the primitives
-for p in glob.glob('kf-d3m-primitives/kf_d3m_primitives/*/*/*.py'):
-    if p in glob.glob('kf-d3m-primitives/kf_d3m_primitives/*/utils/*') or p in glob.glob('/kf-d3m-primitives/kf_d3m_primitives/*/*/__.init__.py'):
+for p in glob.glob('kf_d3m_primitives/*/*/*.py'):
+    if p in glob.glob('kf_d3m_primitives/*/utils/*') or p in glob.glob('kf_d3m_primitives/*/*/__.init__.py'):
         continue
-    f = p.replace('kf-d3m-primitives/', '').replace('/', '.').replace('.py', '')
+    f = p.replace('/', '.').replace('.py', '')
     module = importlib.import_module(f)
     for c in dir(module):
         if 'Primitive' in c and c not in ignore:

--- a/kf_d3m_primitives/remote_sensing/featurizer/streaming_dataset.py
+++ b/kf_d3m_primitives/remote_sensing/featurizer/streaming_dataset.py
@@ -1,0 +1,61 @@
+import struct
+
+import numpy as np
+import pandas as pd
+import torch
+from torch.utils.data import Dataset
+from rsp.moco_r50.data import sentinel_augmentation_valid
+import lzo
+
+class StreamingDataset(Dataset):
+
+    def __init__(
+        self, 
+        df: pd.DataFrame, 
+        image_col: int,
+        inference_model: str = 'moco',
+        decompress_data: bool = False 
+    ):
+        """ load df of compressed np arrays representing imgs into memory"""
+        #self.df = pd.read_csv(self.hyperparams['img_dataframe'], chunksize?)
+        self.df = df
+        self.image_col = image_col
+        self.inference_model = inference_model
+        self.decompress_data = decompress_data
+
+    def __len__(self):
+        return len(self.df)
+
+    def _load_patch_sentinel(
+        self,
+        img: np.ndarray
+    ):
+        """ load and transform sentinel image patch to prep for model """
+        img = img[:12].transpose(1, 2, 0) / 10_000
+        return sentinel_augmentation_valid()(image=img)['image']
+
+    def _delete_record(self, idx):
+        self.df.drop(idx, inplace=True)
+
+    def __getitem__(self, idx):
+        """ get next data point, decompress, tranform for inference """
+        img = self.df.loc[idx][self.image_col]
+        
+        if self.decompress_data:
+            compressed_bytes = img.tobytes()
+            decompressed_bytes = lzo.decompress(compressed_bytes)
+            storage_type, shape_0, shape_1, shape_2 = struct.unpack(
+                'cIII', 
+                decompressed_bytes[:16]
+            )
+            img = np.frombuffer(decompressed_bytes[16:], dtype=storage_type)
+            img = img.reshape(shape_0, shape_1, shape_2)
+
+        if self.inference_model == 'moco':
+            img = self._load_patch_sentinel(img)
+        else:
+            img = torch.Tensor(img)
+
+        self._delete_record(idx)
+        return img
+

--- a/makefile
+++ b/makefile
@@ -4,22 +4,22 @@ build:
 
 volumes:
 	@echo "Downloading large static files"
-	docker-compose run --rm kf-d3m-primitives python3 kf-d3m-primitives/download_volumes.py
+	docker-compose run --rm kf-d3m-primitives python3 download_volumes.py
 run:
 	@echo "Running Kung Fu D3M Primitives Image"
 	docker-compose run --rm kf-d3m-primitives
 
 test:
 	@echo "Running tests for Kung Fu D3M Primitives Image"
-	docker-compose run --rm --entrypoint python3 kf-d3m-primitives -m pytest -s kf-d3m-primitives/tests
+	docker-compose run --rm --entrypoint python3 kf-d3m-primitives -m pytest -s --rootdir=tests tests
 
 annotations:
 	@echo "Generating json annotations for all primitives"
-	docker-compose run --rm kf-d3m-primitives python3 kf-d3m-primitives/generate_annotations.py
+	docker-compose run --rm kf-d3m-primitives python3 generate_annotations.py
 
 pipelines-cpu:
 	@echo "Generating pipeline run documents for all primitives"
-	docker-compose run --rm kf-d3m-primitives python3 kf-d3m-primitives/generate_pipelines.py
+	docker-compose run --rm kf-d3m-primitives python3 generate_pipelines.py
 
 pipelines-gpu:
 	@echo "Generating pipeline run documents for all primitives"


### PR DESCRIPTION
-add `StreamingDataset` to `RemoteSensingPretrained`: loads + transforms images lazily with optional decompression, deletes records from dataframe upon loading
-add optional lzo decompression to `StreamingDataset` and associated test cases in `tests/test_remote_sensing_pretrained.py`
-add lzo install and dependencies in Dockerfile, `RemoteSensingPretrained` metadata
-1 bug fixes to `MlpClassifer`: `squeeze` label tensors when doing multiclass classification
-2 enhancements to  `MlpClassifer`: 
a) remove `spatial_dim` HP, it's now calculated automatically from `feature_dim` HP
b) load serialized `torch` weights file if one exists to support iterative training across separate pipeline runs