### PR TITLE
add crow aggregation to featurizer, add image retrieval primitive and pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -60,4 +60,5 @@ simon/
 punk/
 distil-primitives/
 scratch_dir/
-primitives
+primitives/
+NWPU-RESISC45/

--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ distil-primitives/
 backup_annotations/
 test_data/bigearth-100-single-multi/
 test_data/bigearth-100-single-2c/
+NWPU-RESISC45/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
 FROM registry.gitlab.com/datadrivendiscovery/images/primitives:ubuntu-bionic-python36-v2020.5.18
 
-# RUN apt update && apt install -y default-jre-headless
-
-COPY requirements.txt .
-RUN pip install -r requirements.txt
-
-RUN pip install -e git+https://github.com/kungfuai/d3m-primitives#egg=kf-d3m-primitives --upgrade --exists-action=w
-COPY . .
-RUN pip install -e .[gpu]
-
 RUN sudo apt-get update -y && \ 
     sudo apt-get install -y zlib1g-dev && \ 
     sudo apt-get install -y liblzo2-dev && \ 
     pip install python-lzo
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt
+
+RUN pip install -e git+https://github.com/kungfuai/d3m-primitives@rs/pipeline#egg=kf-d3m-primitives --upgrade --exists-action=w
+COPY . .
+RUN pip install -e .[gpu]
+
+# RUN pip install git+https://github.com/uncharted-distil/distil-primitives#egg=distil-primitives --upgrade --exists-action=w

--- a/README.md
+++ b/README.md
@@ -133,3 +133,6 @@ make pipelines-gpu
 
 2. **MlpClassifierPrimitive**: trains a two-layer neural network classifier on featurized remote sensing imagery. Produces heatmap visualizations for predictions using gradient-based [GradCam](https://arxiv.org/pdf/1610.02391v1.pdf) technique. 
 
+3. **ImageRetrievalPrimitive**: retrieves semantically similar images from an index of un-annotated images using heuristics. Supports an iterative, human-in-the-loop, retrieval pipeline. 
+
+

--- a/kf_d3m_primitives/remote_sensing/classifier/mlp_classifier.py
+++ b/kf_d3m_primitives/remote_sensing/classifier/mlp_classifier.py
@@ -187,6 +187,11 @@ class MlpClassifierPrimitive(SupervisedLearnerPrimitiveBase[Inputs, Outputs, Par
         self._device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
         self._is_fit = False
         self._all_outputs = None
+
+        np.random.seed(random_seed)
+        torch.manual_seed(random_seed)
+        if self.device == 'cuda:0':
+            torch.cuda.manual_seed(random_seed)
     
     def get_params(self) -> Params:
         return Params(

--- a/kf_d3m_primitives/remote_sensing/featurizer/streaming_dataset.py
+++ b/kf_d3m_primitives/remote_sensing/featurizer/streaming_dataset.py
@@ -17,7 +17,6 @@ class StreamingDataset(Dataset):
         decompress_data: bool = False 
     ):
         """ load df of compressed np arrays representing imgs into memory"""
-        #self.df = pd.read_csv(self.hyperparams['img_dataframe'], chunksize?)
         self.df = df
         self.image_col = image_col
         self.inference_model = inference_model

--- a/kf_d3m_primitives/remote_sensing/image_retrieval/gem.py
+++ b/kf_d3m_primitives/remote_sensing/image_retrieval/gem.py
@@ -1,0 +1,18 @@
+import numpy as np
+from numba import njit
+
+@njit()
+def gem(x, p=3):
+    nobs, ndim = x.shape
+    
+    y = np.zeros(ndim)
+    for r in range(nobs):
+        for c in range(ndim):
+            y[c] += x[r,c] ** p
+    
+    y /= nobs
+    
+    for c in range(ndim):
+        y[c] = y[c] ** (1 / p)
+    
+    return y

--- a/kf_d3m_primitives/remote_sensing/image_retrieval/image_retrieval.py
+++ b/kf_d3m_primitives/remote_sensing/image_retrieval/image_retrieval.py
@@ -1,0 +1,271 @@
+import os.path
+import logging
+import sys
+from typing import List
+from time import time
+
+import numpy as np
+import pandas as pd
+from sklearn.decomposition import PCA
+from sklearn.decomposition import TruncatedSVD
+from d3m import container, utils
+from d3m.container import DataFrame as d3m_DataFrame
+from d3m.metadata import hyperparams, params, base as metadata_base
+from d3m.primitive_interfaces.base import CallResult
+from d3m.primitive_interfaces.supervised_learning import SupervisedLearnerPrimitiveBase
+
+from .gem import gem
+
+__author__ = 'Distil'
+__version__ = '1.0.0'
+__contact__ = 'mailto:jeffrey.gleason@kungfu.ai'
+
+Inputs = container.DataFrame
+Outputs = container.DataFrame
+
+logger = logging.getLogger(__name__)
+
+class Params(params.Params):
+    pos_idxs: List[int]
+    neg_idxs: List[int]
+    mis_idxs: np.ndarray
+    d3m_idxs: np.ndarray
+    pos_scores: List[np.ndarray]
+    neg_scores: List[np.ndarray]
+    features: np.ndarray
+    idx_name: str
+
+class Hyperparams(hyperparams.Hyperparams):
+    reduce_method = hyperparams.Enumeration(
+        default = 'pca', 
+        semantic_types = ['https://metadata.datadrivendiscovery.org/types/ControlParameter'],
+        values = ['pca', 'svd'],
+        description = 'dimensionality reduction method that is applied to feature vectors'
+    )
+    reduce_dimension = hyperparams.UniformInt(
+        lower=0,
+        upper=1024,
+        default=128,
+        upper_inclusive=True,
+        semantic_types=["https://metadata.datadrivendiscovery.org/types/ControlParameter"],
+        description="number of dimensions in reduced feature vectors",
+    )
+    gem_p = hyperparams.Uniform(
+        lower=0,
+        upper=sys.maxsize,
+        default=1,
+        upper_inclusive=True,
+        semantic_types=["https://metadata.datadrivendiscovery.org/types/TuningParameter"],
+        description="parameter p in generalized mean pooling; p > 1 increases the constrast of the \
+                    pooled feature map; p = 1 equivalent to average pooling; p = +inf equivalent to \
+                    max pooling.",
+    )
+
+class ImageRetrievalPrimitive(SupervisedLearnerPrimitiveBase[Inputs, Outputs, Params, Hyperparams]):
+    """ Primitive that retrieves semantically similar images from an index of un-annotated images. 
+
+        Training inputs: 1) Feature dataframe, 2) Label dataframe
+        Outputs: D3M dataset with similarity ranking of images 
+    """
+
+    metadata = metadata_base.PrimitiveMetadata({
+        'id': "6dd2032c-5558-4621-9bea-ea42403682da",
+        'version': __version__,
+        'name': 'ImageRetrieval',
+        'keywords': [
+            'remote sensing', 
+            'image retrieval', 
+            'active search', 
+            'active learning', 
+            'euclidean distance',
+            'iterative labeling',
+            'similarity modeling' 
+        ],
+        'source': {
+            'name': __author__,
+            'contact': __contact__,
+            "uris": [
+                "https://github.com/kungfuai/d3m-primitives",
+            ],
+        },
+        "installation": [
+            {"type": "PIP", "package": "cython", "version": "0.29.16"}, 
+            {
+                "type": metadata_base.PrimitiveInstallationType.PIP,
+                "package_uri": "git+https://github.com/kungfuai/d3m-primitives.git@{git_commit}#egg=kf-d3m-primitives".format(
+                    git_commit=utils.current_git_commit(os.path.dirname(__file__)),
+                ),
+            },
+        ],
+        'python_path': 'd3m.primitives.similarity_modeling.iterative_labeling.ImageRetrieval',
+        'algorithm_types': [
+            metadata_base.PrimitiveAlgorithmType.ITERATIVE_LABELING,
+        ],
+        'primitive_family': metadata_base.PrimitiveFamily.SIMILARITY_MODELING,
+    })
+
+    def __init__(self, *, hyperparams: Hyperparams, random_seed: int = 0)-> None:
+        super().__init__(hyperparams=hyperparams, random_seed=random_seed)
+        
+        self.pos_idxs = []
+        self.neg_idxs = []
+        self.pos_scores = []
+        self.neg_scores = []
+        self.features = None
+        self.random_seed = random_seed
+        np.random.seed(random_seed)
+
+    def get_params(self) -> Params:
+        return Params(
+            pos_idxs = self.pos_idxs,
+            neg_idxs = self.neg_idxs,
+            mis_idxs = self.mis_idxs,
+            d3m_idxs = self.d3m_idxs,
+            pos_scores = self.pos_scores,
+            neg_scores = self.neg_scores,
+            features = self.features,
+            idx_name = self.idx_name,
+        )
+
+    def set_params(self, *, params: Params) -> None:
+        self.pos_idxs = params['pos_idxs']
+        self.neg_idxs = params['neg_idxs']
+        self.mis_idxs = params['mis_idxs']
+        self.d3m_idxs = params['d3m_idxs']
+        self.pos_scores = params['pos_scores']
+        self.neg_scores = params['neg_scores']
+        self.features = params['features']
+        self.idx_name = params['idx_name']
+
+    def set_training_data(self, *, inputs: Inputs, outputs: Outputs) -> None:
+        """ set primitive's training data. Outputs are a series of labels, where
+            1 = positive, 0 = negative, -1 = missing. Inputs should only contain 
+            image feature columns and, optionally, a d3mIndex. 
+        
+            Arguments:
+                inputs {Inputs} -- D3M dataframe containing features
+                outputs {Outputs} -- D3M dataframe containing labels
+            
+        """
+
+        index_cols = inputs.metadata.get_columns_with_semantic_type(
+            'https://metadata.datadrivendiscovery.org/types/PrimaryMultiKey'
+        )
+        if len(index_cols):
+            index_col = index_cols[0]
+            self.idx_name = inputs.columns[index_col]
+            self.d3m_idxs = inputs.iloc[:, index_col].values
+        else:
+            self.idx_name = 'index'
+            self.d3m_idxs = np.array([i for i in range(inputs.shape[0])])
+
+        if self.features is None:
+            self.features = self._postprocess(
+                inputs.drop(self.idx_name, axis=1).values
+            )
+        self.features = np.ascontiguousarray(self.features)
+
+        self.annotations = outputs['annotations'].values.astype(int)
+
+        ann_values = np.sort(np.unique(self.annotations))
+        if not np.isin(ann_values, np.array([-1,0,1])).all():
+            raise ValueError("Outputs (i.e., the annotations) must contain only values in [-1,0,1]")
+
+        self.mis_idxs = np.where(self.annotations == -1)[0]
+        
+    def fit(self, *, timeout: float = None, iterations: int = None) -> CallResult[None]:
+        
+        for idx in np.where(self.annotations == 1)[0]:
+            if idx not in self.pos_idxs:
+                self.pos_idxs.append(int(idx))
+                self.pos_scores.append(self.features @ self.features[idx])
+        for idx in np.where(self.annotations == 0)[0]:
+            if idx not in self.neg_idxs:
+                self.neg_idxs.append(int(idx))
+                self.neg_scores.append(self.features @ self.features[idx])
+
+        return CallResult(None)
+                
+    def produce(self, *, inputs: Inputs, timeout: float = None, iterations: int = None) -> CallResult[Outputs]:
+        """ return ranking of unlabeled instances based on similarity to positively and negatively
+            labeled instances
+
+            Ex. 
+                d3mIndex       score
+                    1130    0.586983
+                    11      0.469862
+                    1077    0.394225
+                    1125    0.355335
+                    21      0.353363
+                    
+            Arguments:
+                inputs {Inputs} -- ignores these `inputs`, uses `inputs` from `set_training_data()`
+            
+            Keyword Arguments:
+                timeout {float} -- timeout, not considered (default: {None})
+                iterations {int} -- iterations, not considered (default: {None})
+        """
+
+        pos_scores = np.row_stack(self.pos_scores)
+        pos_scores = gem(pos_scores, p = self.hyperparams['gem_p'])
+
+        if len(self.neg_scores) != 0:
+            neg_scores = np.row_stack(self.neg_scores)
+            neg_scores = gem(neg_scores, p = self.hyperparams['gem_p'])
+            scores = pos_scores / (neg_scores + 1e-12)
+        else:
+            scores = pos_scores
+
+        mis_scores = scores[self.mis_idxs]
+        mis_ranks = self.mis_idxs[np.argsort(-mis_scores)]
+        mis_ranks = self.d3m_idxs[mis_ranks]
+        
+        ranking_df = pd.DataFrame({
+            self.idx_name: mis_ranks,
+            'score': np.flip(np.sort(mis_scores)),
+        })
+        ranking_df = d3m_DataFrame(ranking_df, generate_metadata = True)
+
+        ranking_df.metadata = ranking_df.metadata.add_semantic_type(
+            (metadata_base.ALL_ELEMENTS, 0),
+            "http://schema.org/Integer"
+        )
+        ranking_df.metadata = ranking_df.metadata.add_semantic_type(
+            (metadata_base.ALL_ELEMENTS, 0),
+            'https://metadata.datadrivendiscovery.org/types/PrimaryKey'
+        )
+        ranking_df.metadata = ranking_df.metadata.add_semantic_type(
+            (metadata_base.ALL_ELEMENTS, 1),
+            "http://schema.org/Float"
+        )
+
+        return CallResult(ranking_df)
+
+    def _postprocess(self, features: np.ndarray) -> np.ndarray:
+        """ postprocess feature vectors """ 
+        features = self._normalize(features)
+        features = self._reduce(features)
+        features = self._normalize(features)
+        return features
+
+    def _normalize(self, features: np.ndarray) -> np.ndarray:
+        """ L2 normalize features """ 
+        return features / np.sqrt((features ** 2).sum(axis=-1, keepdims=True))
+
+    def _reduce(self, features: np.ndarray) -> np.ndarray:
+        """ reduce dimensions of feature vectors """ 
+        if self.hyperparams['reduce_method'] == 'pca':
+            reduce_method = PCA(
+                n_components=self.hyperparams['reduce_dimension'], 
+                whiten=True,
+                random_state=self.random_seed
+            )
+
+        elif self.hyperparams['reduce_method'] == 'svd':
+            reduce_method = TruncatedSVD(
+                n_components=self.hyperparams['reduce_dimension']
+            )
+
+        return reduce_method.fit_transform(features)
+
+            

--- a/kf_d3m_primitives/remote_sensing/image_retrieval/image_retrieval_pipeline.py
+++ b/kf_d3m_primitives/remote_sensing/image_retrieval/image_retrieval_pipeline.py
@@ -1,0 +1,255 @@
+from typing import List
+import json
+import os 
+import time
+import subprocess
+
+import numpy as np
+import pandas as pd
+from d3m import index
+from d3m.metadata.base import ArgumentType
+from d3m.metadata.pipeline import Pipeline, PrimitiveStep
+
+from kf_d3m_primitives.pipeline_base import PipelineBase
+
+class ImageRetrievalPipeline(PipelineBase):
+
+    def __init__(
+        self, 
+        gem_p: int = 1,
+        dataset: str = 'LL1_bigearth_landuse_detection'
+    ):
+
+        pipeline_description = Pipeline()
+        pipeline_description.add_input(name="inputs")
+        pipeline_description.add_input(name="annotations")
+
+        # Denormalize
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.data_transformation.denormalize.Common"
+            )
+        )
+        step.add_argument(
+            name="inputs", 
+            argument_type=ArgumentType.CONTAINER, 
+            data_reference="inputs.0"
+        )
+        step.add_output("produce")
+        pipeline_description.add_step(step)
+
+        # DS to DF on input DS
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.data_transformation.dataset_to_dataframe.Common"
+            )
+        )
+        step.add_argument(
+            name="inputs", 
+            argument_type=ArgumentType.CONTAINER, 
+            data_reference="steps.0.produce"
+        )
+        step.add_output("produce")
+        pipeline_description.add_step(step)
+
+        # Satellite Image Loader
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.data_preprocessing.satellite_image_loader.DistilSatelliteImageLoader"
+            )
+        )
+        step.add_argument(
+            name="inputs", 
+            argument_type=ArgumentType.CONTAINER, 
+            data_reference="steps.1.produce"
+        )
+        step.add_hyperparameter(
+            name="return_result",
+            argument_type=ArgumentType.VALUE,
+            data="replace"
+        )
+        step.add_output("produce")
+        pipeline_description.add_step(step)
+
+        # Distil column parser
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.data_transformation.DistilColumnParser"
+            )
+        )
+        step.add_argument(
+            name="inputs",
+            argument_type=ArgumentType.CONTAINER,
+            data_reference="steps.2.produce",
+        )
+        step.add_output("produce")
+        step.add_hyperparameter(
+            name="parsing_semantics",
+            argument_type=ArgumentType.VALUE,
+            data=[
+                "http://schema.org/Integer",
+                "http://schema.org/Float",
+                "https://metadata.datadrivendiscovery.org/types/FloatVector",
+            ],
+        )
+        pipeline_description.add_step(step)
+
+        # parse image semantic types
+        # TODO test without index
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.data_transformation.extract_columns_by_semantic_types.Common"
+            )
+        )
+        step.add_argument(
+            name="inputs",
+            argument_type=ArgumentType.CONTAINER,
+            data_reference="steps.3.produce",
+        )
+        step.add_output("produce")
+        step.add_hyperparameter(
+            name="semantic_types",
+            argument_type=ArgumentType.VALUE,
+            data=[
+                "http://schema.org/ImageObject",
+                'https://metadata.datadrivendiscovery.org/types/PrimaryMultiKey',
+            ],
+        )
+        pipeline_description.add_step(step)
+
+        # remote sensing pretrained
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.remote_sensing.remote_sensing_pretrained.RemoteSensingPretrained"
+            )
+        )
+        step.add_argument(
+            name="inputs",
+            argument_type=ArgumentType.CONTAINER,
+            data_reference="steps.4.produce",
+        )
+        step.add_output("produce")
+        pipeline_description.add_step(step)
+
+        # DS to DF on annotations DS
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.data_transformation.dataset_to_dataframe.Common"
+            )
+        )
+        step.add_argument(
+            name="inputs", 
+            argument_type=ArgumentType.CONTAINER, 
+            data_reference="inputs.1"
+        )
+        step.add_output("produce")
+        pipeline_description.add_step(step)
+
+        # image retrieval primitive
+        step = PrimitiveStep(
+            primitive=index.get_primitive(
+                "d3m.primitives.similarity_modeling.iterative_labeling.ImageRetrieval"
+            )
+        )
+        step.add_argument(
+            name="inputs",
+            argument_type=ArgumentType.CONTAINER,
+            data_reference="steps.5.produce",
+        )
+        step.add_argument(
+            name="outputs",
+            argument_type=ArgumentType.CONTAINER,
+            data_reference="steps.6.produce",
+        )
+        step.add_output("produce")
+        step.add_hyperparameter(
+            name="gem_p",
+            argument_type=ArgumentType.VALUE,
+            data=gem_p
+        )
+        pipeline_description.add_step(step)
+
+        pipeline_description.add_output(
+            name="output ranking", data_reference="steps.7.produce"
+        )
+
+        self.pipeline = pipeline_description
+        self.dataset = dataset
+
+    def make_annotations_dataset(self, n_rows, round_num = 0, num_bands = 12):
+        
+        annotationsDoc = {
+            "dataResources": [{
+                "resID": "annotationsData",
+                "resPath": "/scratch_dir/annotationsData.csv",
+                "resType": "table",
+                "resFormat": { "text/csv": ["csv"]},
+                "columns": [{
+                    "colIndex": 0,
+                    "colName": "annotations",
+                    "colType": "integer",
+                    "role": ["attribute"]
+                }]
+            }]
+        } 
+        with open("/scratch_dir/annotationsDoc.json", "w") as json_file:
+            json.dump(annotationsDoc, json_file)
+
+        if round_num == 0:
+            annotations = np.zeros(n_rows) - 1
+            annotations[0] = 1
+            annotations = pd.DataFrame({"annotations": annotations.astype(int)})
+        else:
+            annotations = pd.read_csv("/scratch_dir/annotationsData.csv")
+            ranking = pd.read_csv("/scratch_dir/rankings.csv")
+            test_index = pd.read_csv(
+                f"/datasets/seed_datasets_current/{self.dataset}/TEST/dataset_TEST/tables/learningData.csv"
+            )['d3mIndex'].values
+            
+            top_idx = np.where(test_index == ranking.iloc[0,0])[0][0] // num_bands
+            human_annotation = np.random.randint(2)
+            annotations.iloc[top_idx, 0] = human_annotation
+
+        annotations.to_csv("/scratch_dir/annotationsData.csv", index=False)
+
+    def delete_annotations_dataset(self):
+        subprocess.run(['rm', "/scratch_dir/annotationsDoc.json"], check = True)
+        subprocess.run(['rm', "/scratch_dir/annotationsData.csv"], check = True)
+        subprocess.run(['rm', "/scratch_dir/rankings.csv"], check = True)
+
+    def fit_produce(self):
+        
+        if not os.path.isfile(self.outfile_string):
+            raise ValueError("Must call 'write_pipeline()' method first")
+        
+        proc_cmd = [
+            "python3",
+            "-m",
+            "d3m",
+            "runtime", 
+            "-d", 
+            "/datasets",
+            "-v" ,
+            "/static_volumes",
+            "-s",
+            "/scratch_dir",
+            "fit-produce", 
+            "-p", 
+            self.outfile_string,
+            "-i",
+            f"/datasets/seed_datasets_current/{self.dataset}/TEST/dataset_TEST/datasetDoc.json",
+            "-i",
+            "/scratch_dir/annotationsData.csv",
+            "-r",
+            f"/datasets/seed_datasets_current/{self.dataset}/{self.dataset}_problem/problemDoc.json",
+            "-t",
+            f"/datasets/seed_datasets_current/{self.dataset}/TEST/dataset_TEST/datasetDoc.json",
+            "-t",
+            "/scratch_dir/annotationsData.csv",
+            "-o",
+            f"/scratch_dir/rankings.csv"
+        ]
+
+        st = time.time()
+        subprocess.run(proc_cmd, check=True)
+        print(f'Fitting and producing pipeline took {(time.time() - st) / 60} mins')

--- a/makefile
+++ b/makefile
@@ -15,6 +15,7 @@ run-gpu:
 		--mount type=bind,source=/home/ubuntu/d3m/d3m-primitives/datasets,target=/datasets \
 		--mount type=bind,source=/home/ubuntu/d3m/d3m-primitives/static_volumes,target=/static_volumes \
 		--mount type=bind,source=/home/ubuntu/d3m/d3m-primitives/scratch_dir,target=/scratch_dir \
+		--mount type=bind,source=/home/ubuntu/d3m/d3m-primitives/tests,target=/tests \
 		--mount type=bind,source=/home/ubuntu/d3m/d3m-primitives/kf_d3m_primitives,target=/kf_d3m_primitives \
 		-it kf-d3m-primitives /bin/bash
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ torchvision==0.5.0
 opencv-python-headless==4.1.1.26
 albumentations==0.4.6
 tifffile==2020.8.13
+tqdm==4.48.2
 git+https://github.com/uncharted-distil/punk@8b101eca26b5f9a3df2a65aab2733bd404965578#egg=punk
 git+https://github.com/uncharted-distil/object-detection-retinanet@f4cba645c61a7bc068608356c6194adbe34f8e9e#egg=object_detection_retinanet
 git+https://github.com/uncharted-distil/simon@00422bbdc9caa09b867f8b5f583487b59b605de0#egg=Simon

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
         "gluonts==0.5.2", 
         "albumentations==0.4.6",
         "tifffile==2020.8.13",
+        "tqdm==4.48.2",
         "punk @ git+https://github.com/uncharted-distil/punk@8b101eca26b5f9a3df2a65aab2733bd404965578#egg=punk",
         "object_detection_retinanet @ git+https://github.com/uncharted-distil/object-detection-retinanet@f4cba645c61a7bc068608356c6194adbe34f8e9e#egg=object_detection_retinanet",
         "Simon @ git+https://github.com/uncharted-distil/simon@00422bbdc9caa09b867f8b5f583487b59b605de0#egg=Simon",
@@ -56,6 +57,7 @@ setup(
             "classification.inceptionV3_image_feature.Gator = kf_d3m_primitives.image_classification.imagenet_transfer_learning.gator:GatorPrimitive",
             "remote_sensing.remote_sensing_pretrained.RemoteSensingPretrained = kf_d3m_primitives.remote_sensing.featurizer.remote_sensing_pretrained:RemoteSensingPretrainedPrimitive",
             "remote_sensing.mlp.MlpClassifier = kf_d3m_primitives.remote_sensing.classifier.mlp_classifier:MlpClassifierPrimitive",
+            "similarity_modeling.iterative_labeling.ImageRetrieval = kf_d3m_primitives.remote_sensing.image_retrieval.image_retrieval:ImageRetrievalPrimitive",
         ],
     },
 )

--- a/tests/test_image_retrieval.py
+++ b/tests/test_image_retrieval.py
@@ -1,0 +1,185 @@
+import os
+from glob import glob
+import time
+import json
+
+from PIL import Image
+import pandas as pd
+import numpy as np
+import torchvision as tv
+from rsp.data import bilinear_upsample, BANDS
+from tifffile import imread as tiffread
+from d3m.container import DataFrame as d3m_DataFrame
+from d3m.metadata import base as metadata_base
+
+from kf_d3m_primitives.remote_sensing.featurizer.remote_sensing_pretrained import (
+    RemoteSensingPretrainedPrimitive, 
+    Hyperparams as rs_hp
+)
+from kf_d3m_primitives.remote_sensing.image_retrieval.image_retrieval import (
+    ImageRetrievalPrimitive, 
+    Hyperparams as ir_hp
+)
+from kf_d3m_primitives.remote_sensing.image_retrieval.image_retrieval_pipeline import ImageRetrievalPipeline
+
+
+amdim_path = '/static_volumes/8946fea864c29ed785e00a9cbaa9a50295eb5a334b014f27ba20927104b07f46'
+moco_path = '/static_volumes/fcc8a5a05fa7dbad8fc55584a77fc5d2c407e03a88610267860b45208e152f1f'
+
+def load_nwpu(data_dir: str = '/NWPU-RESISC45', n_imgs = 200):
+    paths = sorted(glob(os.path.join(data_dir, '*/*')))
+    paths = [os.path.abspath(p) for p in paths]
+    imgs = [Image.open(p) for p in paths[:n_imgs]]
+    labels  = [os.path.basename(os.path.dirname(p)) for p in paths[:n_imgs]]
+
+    transform = tv.transforms.Compose([
+        tv.transforms.ToTensor(),
+        tv.transforms.Normalize(
+            mean = (0.3680, 0.3810, 0.3436),
+            std  = (0.2034, 0.1854, 0.1848),
+        )
+    ])
+    imgs = [transform(img) for img in imgs]
+
+    imgs = d3m_DataFrame(pd.DataFrame({'imgs': imgs}))
+    labels = np.array(labels)
+    return imgs, labels
+
+def load_patch(imname):
+    patch = [
+        tiffread(f'{imname}_{band}.tif')
+        for band in BANDS
+    ]
+    patch = np.stack([bilinear_upsample(xx) for xx in patch]) 
+    return patch
+
+def load_big_earthnet():
+    fnames  = sorted(glob('/test_data/bigearth-100-single/*/*.tif'))
+    imnames = sorted(list(set(['_'.join(f.split('_')[:-1]) for f in fnames])))
+    imgs = [
+        load_patch(img_path).astype(np.float32) 
+        for img_path in imnames
+    ]
+    imgs_df = pd.DataFrame({'image_col': imgs, 'index': range(len(imgs))})
+    imgs_df = d3m_DataFrame(imgs_df)
+    imgs_df.metadata = imgs_df.metadata.add_semantic_type(
+        (metadata_base.ALL_ELEMENTS, 1),
+        'https://metadata.datadrivendiscovery.org/types/PrimaryKey'
+    )
+
+    y = [i.split('/')[3] for i in imnames]
+
+    return imgs_df, np.array(y)
+
+def iterative_labeling(features, labels, seed_idx = 2, n_rounds = 5):
+
+    # initial query image
+    y = (labels == labels[seed_idx]).astype(np.int)
+    annotations = np.zeros(features.shape[0]) - 1
+    annotations[seed_idx] = 1
+
+    sampler = ImageRetrievalPrimitive(
+        hyperparams=ir_hp(
+            ir_hp.defaults(),
+            reduce_dimension=32
+        )
+    )
+
+    n_pos, n_neg = 1, 0
+    for i in range(n_rounds):
+        
+        # generate ranking by similarity
+        sampler.set_training_data(
+            inputs = features, 
+            outputs = d3m_DataFrame(pd.DataFrame({'annotations': annotations}))
+        )
+        sampler.fit()
+        ranking_df = sampler.produce(inputs = features).value
+        assert ranking_df.shape[0] == features.shape[0] - i - 1
+
+        exc_labeled = ranking_df['index'].values
+        inc_labeled = np.concatenate((sampler.pos_idxs, exc_labeled))
+
+        # simulate human labeling
+        next_idx = exc_labeled[0]
+        next_label = y[next_idx]
+        annotations[next_idx] = next_label
+
+        if next_label == 1:
+            n_pos += 1
+        else:
+            n_neg += 1
+
+        # evaluate ranking against ground truth
+        results = {
+            'round': i + 1,
+            'next_idx': int(next_idx),
+            'next_label': next_label,
+            'n_pos': n_pos,
+            'n_neg': n_neg,
+            'a_p': [
+                float(y[inc_labeled[:k]].mean()) 
+                for k in 2 ** np.arange(11)
+            ], # precision, including labeled
+            'u_p': [
+                float(y[exc_labeled[:k]].mean()) 
+                for k in 2 ** np.arange(11)
+            ], # precision, excluding labeled
+            'r_p': [
+                float(y[inc_labeled[:k]].sum()/y.sum()) 
+                for k in 2**np.arange(11)
+            ], # recall, including labeled
+        }
+        print()
+        print(results)
+
+# def test_nwpu():
+#     train_inputs, labels = load_nwpu()
+
+#     featurizer = RemoteSensingPretrainedPrimitive(
+#         hyperparams=rs_hp(
+#             rs_hp.defaults(),
+#             inference_model = 'moco',
+#             use_columns = [0],
+#         ),
+#         volumes = {'amdim_weights': amdim_path, 'moco_weights': moco_path}
+#     )
+#     features = featurizer.produce(inputs = train_inputs).value
+#     #features.to_pickle("dummy.pkl")
+#     #features = pd.read_pickle("dummy.pkl")
+
+#     iterative_labeling(features, labels)
+
+def test_big_earthnet():
+
+    train_inputs, labels = load_big_earthnet()
+
+    featurizer = RemoteSensingPretrainedPrimitive(
+        hyperparams=rs_hp(
+            rs_hp.defaults(),
+            inference_model = 'moco',
+            use_columns = [0],
+        ),
+        volumes = {'amdim_weights': amdim_path, 'moco_weights': moco_path}
+    )
+    features = featurizer.produce(inputs = train_inputs).value
+    features.to_pickle("dummy.pkl")
+    # features = pd.read_pickle("dummy.pkl")
+
+    iterative_labeling(features, labels)
+
+def test_iterative_pipeline(
+    dataset = 'LL1_bigearth_landuse_detection', 
+    n_rows = 2188,
+    n_rounds = 2,
+):
+    pipeline = ImageRetrievalPipeline(dataset = dataset)
+    pipeline.write_pipeline()
+    for i in range(n_rounds):
+        print(f'Running round {i} pipeline...')
+        pipeline.make_annotations_dataset(n_rows, round_num = i)
+        pipeline.fit_produce()
+    pipeline.delete_pipeline()
+    pipeline.delete_annotations_dataset()
+
+

--- a/tests/test_mlp_classifier.py
+++ b/tests/test_mlp_classifier.py
@@ -40,7 +40,6 @@ def load_inputs():
     imgs_df = pd.DataFrame({'image_col': imgs, 'dummy_idx': range(len(imgs))})
 
     y = [i.split('/')[3] for i in imnames]
-    #tgts = LabelEncoder().fit_transform(y)
     tgts_df = pd.DataFrame({'target': y})
 
     return (


### PR DESCRIPTION
-add CROW (cross-dimensional weighting for aggregated deep convolutional features) aggregation method to featurizer. This aggregation is applied when `pool_features` is True (default). 

-add image retrieval primitive (supervised learner base class) that takes image features (Inputs) and human annotations (Outputs) and produces a ranking of the images that have not yet been annotated according to similarity. Look at the `produce()` method docstring for an example of the output data frame contents.

-add image retrieval pipeline that takes two inputs, the BigEarthNet dataset, and an annotations dataset. The `test_iterative_pipeline()` test case in `test_image_retrieval.py` simulates multiple rounds of human-in-the-loop annotations of the top-ranked, un-annotated image. This example pipeline includes the featurization step, but that would be done offline in Distil.  

-can ignore small changes to .dockerignore, .gitignore, Dockerfile, README, mlp_classifier, streaming_dataset, makefile, requirements, setup, test_mlp_classifier