### PR TITLE
Add license metadata to PyPI package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ setup(
     name="kf-d3m-primitives",
     version="0.6.0",
     description="All Kung Fu D3M primitives as a single library",
+    license='Apache-2.0',
     packages=find_packages(exclude="scripts"),
     setkeywords=['d3m_primitive'],
     install_requires=[


### PR DESCRIPTION
The package shows as `UNKNOWN` right now and people have to come to the repository to find the LICENSE file.