### PR TITLE
fixes default index name from "index" -> "d3mIndex"

### DIFF
--- a/kf_d3m_primitives/remote_sensing/image_retrieval/image_retrieval.py
+++ b/kf_d3m_primitives/remote_sensing/image_retrieval/image_retrieval.py
@@ -191,7 +191,7 @@ class ImageRetrievalPrimitive(
             self.d3m_idxs = inputs[self.idx_name].values
             input_features = inputs.drop(self.idx_name, axis=1).values
         else:
-            self.idx_name = "index"
+            self.idx_name = "d3mIndex"
             self.d3m_idxs = np.arange(inputs.shape[0])
             input_features = inputs.values
 


### PR DESCRIPTION
The default value "index" is incorrect for the d3m use case.
The proper value is "d3mIndex".