### PR TITLE
Changing hdbscan version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pillow==7.1.2
 tslearn==0.4.1
 statsmodels==0.11.1
 pmdarima==1.6.1
-hdbscan==0.8.26
+hdbscan>=0.8.26
 requests==2.23.0
 shap==0.37.0
 gluonts==0.5.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "tslearn==0.4.1",
         "statsmodels==0.11.1",
         "pmdarima==1.6.1",
-        "hdbscan==0.8.26",
+        "hdbscan>=0.8.26",
         "requests==2.23.0",
         "shap==0.37.0",
         "torchvision>=0.5.0",


### PR DESCRIPTION
The version of hdbscan installed with kf-d3m-primitives (0.8.26) is causing issues with autonml that are fixed by upgrading to hdbscan 0.8.28.  Vedant Sanil suggested that I edit the requirement to allow newer versions of hdbscan.